### PR TITLE
add error handling to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ restClient.getcurrencies().then((result) => {
   console.log("Currencies: ", result);
 });
 
-restClient.index((result) => {
+restClient.index((result, error) => {
+  if(error) {
+    return console.log("Error:", error);
+  }
   console.log("Index: ", result)
 });
 ```


### PR DESCRIPTION
In nodejs [the standard for async functions](https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/) (such as API calls) is to provide the callback function with 2 parameters: an error (if any, null if not) and the response.

This library does it the other way around, with the error as a second argument. This PR documents this behavior in the example.

