### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "url": "https://github.com/deribit/deribit-api-js"
   },
   "dependencies": {
-    "create-hash": "^1.1.2",
-    "node-rest-client": "^3.0.3",
-    "q": "^1.4.1"
+    "create-hash": "^1.2.0",
+    "node-rest-client": "^3.1.0",
+    "q": "^1.5.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Updating dependencies as `deribit-api` relies on `node-rest-client`, which relies on `debug`, which has a low-severity [DoS vulnerability](https://www.npmjs.com/advisories/534) in version `2.6.8` and lower.