### PR TITLE
Add missing currency parameter to function getsummary - backwards compatible

### DIFF
--- a/src/RestClient.js
+++ b/src/RestClient.js
@@ -172,8 +172,11 @@ RestClient.prototype.getlasttrades = function(instrument, count, since, callback
   return this.request("/api/v1/public/getlasttrades", options, callback);
 };
 
-RestClient.prototype.getsummary = function(instrument, callback) {
-  return this.request("/api/v1/public/getsummary", {instrument: instrument}, callback);
+RestClient.prototype.getsummary = function(instrument, currency, callback) {
+  if (typeof currency === 'function') {
+    callback = currency;
+  }
+  return this.request("/api/v1/public/getsummary", {instrument: instrument, currency: currency}, callback);
 };
 
 RestClient.prototype.index = function(callback) {


### PR DESCRIPTION
According to the online documentation `getsummary` can provide for all instruments if the param `instrument` is set to `all` - but the parameters for `currency` also has to be set to `all`, otherwise only BTC instruments are provided.

As the `currency` param is omited on the `getsummary` function, I've added it while considering backwards compatibility.